### PR TITLE
Add a flag to decide to build old zip based OTA

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -1665,7 +1665,9 @@ $(INTERNAL_OTA_PACKAGE_TARGET): $(BUILT_TARGET_FILES_PACKAGE) $(DISTTOOLS)
 	@echo -e ${CL_YLW}"Package OTA:"${CL_RST}" $@"
 	$(hide) MKBOOTIMG=$(MKBOOTIMG) \
 	   $(OTA_FROM_TARGET_SCRIPT) -v \
+	   ifneq ($(NO_BLOCK_OTA),true)
 	   --block \
+	   endif
 	   -p $(HOST_OUT) \
 	   -k $(KEY_CERT_PAIR) \
 	   --backup=$(backuptool) \


### PR DESCRIPTION
By default this will keep block OTA builds (with .dat files), but if you set NO_BLOCK_OTA to true in BoardConfig it will avoid --block flag, building an old zip based OTA (without .dat files).